### PR TITLE
Allow to choose any terminal

### DIFF
--- a/README.org
+++ b/README.org
@@ -26,7 +26,7 @@ In your ~.emacs~ or ~.emacs.d/init.el~ file, add the following:
   (setq org-babel-default-header-args:tmux
     '((:results . "silent")		;
       (:session . "default")	; The default tmux session to send code to
-      (:socket  . nil)              ; The default tmux socket to communicate with
+      (:socket  . nil)))        ; The default tmux socket to communicate with
       ;; You can use "xterm" and "gnome-terminal".
       ;; On mac, you can use "iterm" as well.
       (:terminal . "gnome-terminal")))
@@ -34,6 +34,11 @@ In your ~.emacs~ or ~.emacs.d/init.el~ file, add the following:
   ;; The tmux sessions are prefixed with the following string.
   ;; You can customize this if you like.
   (setq org-babel-tmux-session-prefix "ob-")
+
+  ;; The terminal that will be used.
+  ;; You can also customize the options passed to the terminal.
+  (setq org-babel-tmux-terminal "xterm")
+  (setq org-babel-tmux-terminal-opts '("-T" "ob-tmux" "-e"))
 
   ;; Finally, if your tmux is not in your $PATH for whatever reason, you
   ;; may set the path to the tmux binary as follows:
@@ -49,13 +54,14 @@ If you use =use-package=, you can also write
     (org-babel-default-header-args:tmux
      '((:results . "silent")	 ;
        (:session . "default")	 ; The default tmux session to send code to
-       (:socket  . nil)            ; The default tmux socket to communicate with
-       ;; You can use "xterm" and "gnome-terminal".
-       ;; On mac, you can use "iterm" as well.
-       (:terminal . "gnome-terminal")))
+       (:socket  . nil)))        ; The default tmux socket to communicate with
     ;; The tmux sessions are prefixed with the following string.
     ;; You can customize this if you like.
     (org-babel-tmux-session-prefix "ob-")
+    ;; The terminal that will be used.
+    ;; You can also customize the options passed to the terminal.
+    (setq org-babel-tmux-terminal "xterm")
+    (setq org-babel-tmux-terminal-opts '("-T" "ob-tmux" "-e"))
     ;; Finally, if your tmux is not in your $PATH for whatever reason, you
     ;; may set the path to the tmux binary as follows:
     (org-babel-tmux-location "/usr/bin/tmux"))
@@ -163,10 +169,6 @@ it is already logged in remotely.
 * Known bugs and or possible issues
 My tmux indexes start at 1. By default, tmux window indexes start at
 zero. This might lead to problems. I have not yet checked.
-
-Terminals other than xterm and gnome-terminal have not been
-tested. If you have positive or negative experiences with any other
-terminal, let me know.
 
 I will try to respond within a week to any issues raised. I cannot
 promise I will fix them.

--- a/ob-tmux.el
+++ b/ob-tmux.el
@@ -190,7 +190,7 @@ automatically space separated."
   "Start a TERMINAL window with tmux attached to session.
 
 Argument OB-SESSION: the current ob-tmux session."
-  (let* ((process-name (concat "org-babel: terminal")))
+  (let ((process-name "org-babel: terminal")
     (unless (ob-tmux--socket ob-session)
       (if (string-equal terminal "xterm")
 	  (start-process process-name "*Messages*"

--- a/ob-tmux.el
+++ b/ob-tmux.el
@@ -60,6 +60,11 @@ Change in case you want to use a different tmux than the one in your $PATH."
   :group 'org-babel
   :type 'string)
 
+(defcustom org-babel-tmux-terminal-opts '("--")
+  "The list of options that will be passed to the terminal."
+  :group 'org-babel
+  :type 'list)
+
 (defvar org-babel-default-header-args:tmux
   '((:results . "silent")
     (:session . "default")
@@ -193,10 +198,10 @@ Argument OB-SESSION: the current ob-tmux session."
 			 "-T" (ob-tmux--target ob-session)
 			 "-e" org-babel-tmux-location "attach-session"
 			 "-t" (ob-tmux--target ob-session))
-	(start-process process-name "*Messages*"
-		       terminal "--"
-		       org-babel-tmux-location "attach-session"
-		       "-t" (ob-tmux--target ob-session))))))
+	  (apply 'start-process (append (list process-name "*Messages*" terminal)
+									org-babel-tmux-terminal-opts
+									(list org-babel-tmux-location "attach-session"
+										  "-t" (ob-tmux--target ob-session))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tmux interaction


### PR DESCRIPTION
This PR build on the #8.

Example of use:
```elisp
(setq org-babel-tmux-terminal "xterm")
(setq org-babel-tmux-terminal-opts '("-T" "ob-tmux" "-e"))
```
will spawn `xterm -T ob-tmux -e tmux attach-session ...`

I can now start my terminal (alacritty) with a specific config and a specific title. And It will be put, automatically, in a i3wm scratchpad :)