### PR TITLE
Fix issue when creating session with non-default window name

### DIFF
--- a/ob-tmux.el
+++ b/ob-tmux.el
@@ -227,7 +227,7 @@ Argument OB-SESSION: the current ob-tmux session."
      "-d" ;; just create the session, don't attach.
      "-c" (expand-file-name "~") ;; start in home directory
      "-s" (ob-tmux--session ob-session)
-     "-n" (ob-tmux--window-default ob-session))))
+     "-n" org-babel-tmux-default-window-name)))
 
 (defun ob-tmux--create-window (ob-session)
   "Create a tmux window in session if it does not yet exist.


### PR DESCRIPTION
Before this change if I executed a code block like the following

  #+begin_src tmux :session default:foo
    echo hello world
  #+end_src

and no session named "default" exists, then first a session with a window named "foo" would be created by (ob-tmux--create-session) and then (sometimes) an additional window with the name "foo" would be created by (ob-tmux--create-window).  This has lead in my case to some follow up failures.  Therefore this change where always a window with the default name is created for new sessions.